### PR TITLE
New Dockerfile for operator deployments

### DIFF
--- a/workspace/sampleaceproject/Dockerfile
+++ b/workspace/sampleaceproject/Dockerfile
@@ -1,7 +1,2 @@
-FROM ibmcom/ace:latest
-
-ARG PROJECT1
-RUN mkdir -p /home/aceuser/bars
-COPY workspace/sampleaceproject/gen/*.bar /home/aceuser/bars
-RUN chown aceuser:aceuser /home/aceuser/bars
-RUN ace_compile_bars.sh
+FROM cp.icr.io/cp/appc/ace-server-prod@sha256:8df2fc5e76aa715e2b60a57920202cd000748476558598141a736c1b0eb1f1a3
+COPY *.bar /home/aceuser/initial-config/bars/


### PR DESCRIPTION
The latest CP4I is stuck in a continuously restarting state with the current base image for the Dockerfile.